### PR TITLE
Add public subscriber registration linked to admin login

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "accounts"

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,33 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+
+
+class SubscriptionUserCreationForm(UserCreationForm):
+    username = forms.CharField(
+        label="Nome de usuário",
+        widget=forms.TextInput(attrs={
+            "autofocus": True,
+            "placeholder": "Informe um nome de usuário",
+        }),
+    )
+    password1 = forms.CharField(
+        label="Senha",
+        strip=False,
+        widget=forms.PasswordInput(attrs={
+            "placeholder": "Crie uma senha",
+        }),
+        help_text=UserCreationForm().fields["password1"].help_text,
+    )
+    password2 = forms.CharField(
+        label="Confirmação de senha",
+        strip=False,
+        widget=forms.PasswordInput(attrs={
+            "placeholder": "Repita a senha",
+        }),
+        help_text="Repita a mesma senha para confirmação.",
+    )
+
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = ("username",)

--- a/accounts/templates/registration/register.html
+++ b/accounts/templates/registration/register.html
@@ -1,0 +1,69 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block title %}{% trans "Registrar" %} | {{ block.super }}{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/css/login.css' %}">
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} login{% endblock %}
+
+{% block content %}
+  <div id="content-main" class="register-form">
+    <h1 class="login-heading">{% trans "Criar nova conta" %}</h1>
+    {% if messages %}
+      {% for message in messages %}
+        <p class="successnote">{{ message }}</p>
+      {% endfor %}
+    {% endif %}
+
+    {% if form.errors and not form.non_field_errors %}
+      <p class="errornote">
+        {% blocktranslate count counter=form.errors.items|length %}Por favor corrija o erro abaixo.{% plural %}Por favor corrija os erros abaixo.{% endblocktranslate %}
+      </p>
+    {% endif %}
+
+    {% if form.non_field_errors %}
+      {% for error in form.non_field_errors %}
+        <p class="errornote">{{ error }}</p>
+      {% endfor %}
+    {% endif %}
+
+    <form method="post" novalidate>
+      {% csrf_token %}
+      <div class="form-row">
+        {{ form.username.errors }}
+        {{ form.username.label_tag }}
+        {{ form.username }}
+        {% if form.username.help_text %}
+          <div class="help">{{ form.username.help_text|safe }}</div>
+        {% endif %}
+      </div>
+      <div class="form-row">
+        {{ form.password1.errors }}
+        {{ form.password1.label_tag }}
+        {{ form.password1 }}
+        {% if form.password1.help_text %}
+          <div class="help">{{ form.password1.help_text|safe }}</div>
+        {% endif %}
+      </div>
+      <div class="form-row">
+        {{ form.password2.errors }}
+        {{ form.password2.label_tag }}
+        {{ form.password2 }}
+        {% if form.password2.help_text %}
+          <div class="help">{{ form.password2.help_text|safe }}</div>
+        {% endif %}
+      </div>
+      <div class="submit-row">
+        <input type="submit" value="{% trans 'Registrar' %}">
+      </div>
+    </form>
+
+    <div class="password-reset-link">
+      <a href="{% url 'admin:login' %}">{% trans 'Já possui uma conta? Acesse aqui.' %}</a>
+    </div>
+  </div>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import RegisterView
+
+app_name = "accounts"
+
+urlpatterns = [
+    path("registrar/", RegisterView.as_view(), name="register"),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,0 +1,25 @@
+from django.contrib import messages
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import Group
+from django.urls import reverse_lazy
+from django.views.generic.edit import FormView
+
+from .forms import SubscriptionUserCreationForm
+
+
+class RegisterView(FormView):
+    template_name = "registration/register.html"
+    form_class = SubscriptionUserCreationForm
+    success_url = reverse_lazy("admin:login")
+
+    def form_valid(self, form: UserCreationForm):
+        user = form.save()
+        group = Group.objects.filter(pk=1, name="assinante").first()
+        if not group:
+            group, _ = Group.objects.get_or_create(name="assinante")
+        user.groups.add(group)
+        messages.success(
+            self.request,
+            "Cadastro realizado com sucesso! Você já pode acessar com suas credenciais.",
+        )
+        return super().form_valid(form)

--- a/core/settings.py
+++ b/core/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
 
     "admin_interface",
     "colorfield",
+    "accounts",
 
     'django.contrib.admin',
     'django.contrib.auth',
@@ -84,7 +85,7 @@ ROOT_URLCONF = 'core.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / "templates"],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/', include('accounts.urls', namespace='accounts')),
 ]

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,79 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static 'admin/css/login.css' %}">
+{{ form.media }}
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} login{% endblock %}
+
+{% block usertools %}{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block nav-sidebar %}{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block nav-breadcrumbs %}{% endblock %}
+
+{% block content %}
+{% if form.errors and not form.non_field_errors %}
+<p class="errornote">
+{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors
+below.{% endblocktranslate %}
+</p>
+{% endif %}
+
+{% if form.non_field_errors %}
+{% for error in form.non_field_errors %}
+<p class="errornote">
+    {{ error }}
+</p>
+{% endfor %}
+{% endif %}
+
+{% if messages %}
+  {% for message in messages %}
+    <p class="{% if 'success' in message.tags %}successnote{% else %}{{ message.tags|default:'info' }}note{% endif %}">{{ message }}</p>
+  {% endfor %}
+{% endif %}
+
+<div id="content-main">
+
+{% if user.is_authenticated %}
+<p class="errornote">
+{% blocktranslate trimmed %}
+    You are authenticated as {{ username }}, but are not authorized to
+    access this page. Would you like to login to a different account?
+{% endblocktranslate %}
+</p>
+{% endif %}
+
+<form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
+  <div class="form-row">
+    {{ form.username.errors }}
+    {{ form.username.label_tag }} {{ form.username }}
+  </div>
+  <div class="form-row">
+    {{ form.password.errors }}
+    {{ form.password.label_tag }} {{ form.password }}
+    <input type="hidden" name="next" value="{{ next }}">
+  </div>
+  {% url 'admin_password_reset' as password_reset_url %}
+  {% if password_reset_url %}
+  <div class="password-reset-link">
+    <a href="{{ password_reset_url }}">{% translate 'Forgotten your password or username?' %}</a>
+  </div>
+  {% endif %}
+  <div class="submit-row">
+    <input type="submit" value="{% translate 'Log in' %}">
+  </div>
+</form>
+
+<div class="password-reset-link register-link">
+  <a href="{% url 'accounts:register' %}">Não tem uma conta? Registre-se aqui.</a>
+</div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an accounts app with a subscriber-focused registration form and view that assigns new users to the "assinante" group
- expose a dedicated registration page and link it from the admin login so unauthenticated users can create accounts
- configure Django templates to include the new pages and surface success feedback on the admin login screen

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68da9a0c407c8332b402b718d4dc730e